### PR TITLE
Core upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.3
+FROM alpine:3.20.3
 
 # ---
 # upgrade system and installed dependencies for security patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ RUN --mount=type=cache,target=/var/cache/apk \
     cd /tmp; \
     # Headscale
     { \
-        export HEADSCALE_VERSION=0.22.3; \
+        export HEADSCALE_VERSION=0.23.0; \
         case "$(arch)" in \
         x86_64) \
             export \
                 HEADSCALE_ARCH=amd64 \
-                HEADSCALE_SHA256=41eb475ba94d2f4efdd5b90ca76d3926a0fc0b561baabf6190ca32335c9102d2 \
+                HEADSCALE_SHA256=d9193dad4b070b9b3f6d54c8f14366952944b6e917672c0bc1dfd8f5491287a7 \
             ; \
             ;; \
         aarch64) \
             export \
                 HEADSCALE_ARCH=arm64 \
-                HEADSCALE_SHA256=c36b469a30e87efc6616abd7f8df429de2a11896d311037580ac0b9c2f6b53a6 \
+                HEADSCALE_SHA256=99fa9b2944c50759882b578e78aa11968d6fdec9bbfeced88237a1138b89e9fe \
             ; \
             ;; \
         esac; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,18 +36,18 @@ RUN --mount=type=cache,target=/var/cache/apk \
     }; \
     # Litestream
     { \
-        export LITESTREAM_VERSION=0.3.11; \
+        export LITESTREAM_VERSION=0.3.13; \
         case "$(arch)" in \
         x86_64) \
             export \
                 LITESTREAM_ARCH=amd64 \
-                LITESTREAM_SHA256=83b63dffb1ef5f3e54e9399dcf750a35a6a9b3b20a3ca5601653cce36146c51b \
+                LITESTREAM_SHA256=eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a9077948818ba0 \
             ; \
             ;; \
         aarch64) \
             export \
                 LITESTREAM_ARCH=arm64 \
-                LITESTREAM_SHA256=37be08622b91239ca1a4d417b37889cbac2c6aa83bfcfa6881bcaa7642fc8ee2 \
+                LITESTREAM_SHA256=9585f5a508516bd66af2b2376bab4de256a5ef8e2b73ec760559e679628f2d59 \
             ; \
             ;; \
         esac; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,20 +14,44 @@ RUN --mount=type=cache,target=/var/cache/apk \
     cd /tmp; \
     # Headscale
     { \
-        export \
-            HEADSCALE_VERSION=0.22.3 \
-            HEADSCALE_SHA256=41eb475ba94d2f4efdd5b90ca76d3926a0fc0b561baabf6190ca32335c9102d2; \
-        wget -q -O headscale https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_amd64; \
+        export HEADSCALE_VERSION=0.22.3; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                HEADSCALE_ARCH=amd64 \
+                HEADSCALE_SHA256=41eb475ba94d2f4efdd5b90ca76d3926a0fc0b561baabf6190ca32335c9102d2 \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                HEADSCALE_ARCH=arm64 \
+                HEADSCALE_SHA256=c36b469a30e87efc6616abd7f8df429de2a11896d311037580ac0b9c2f6b53a6 \
+            ; \
+            ;; \
+        esac; \
+        wget -q -O headscale https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_${HEADSCALE_ARCH}; \
         echo "${HEADSCALE_SHA256} *headscale" | sha256sum -c - >/dev/null 2>&1; \
         chmod +x headscale; \
         mv headscale /usr/local/bin/; \
     }; \
     # Litestream
     { \
-        export \
-            LITESTREAM_VERSION=0.3.11 \
-            LITESTREAM_SHA256=83b63dffb1ef5f3e54e9399dcf750a35a6a9b3b20a3ca5601653cce36146c51b; \
-        wget -q -O litestream.tar.gz https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz; \
+        export LITESTREAM_VERSION=0.3.11; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                LITESTREAM_ARCH=amd64 \
+                LITESTREAM_SHA256=83b63dffb1ef5f3e54e9399dcf750a35a6a9b3b20a3ca5601653cce36146c51b \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                LITESTREAM_ARCH=arm64 \
+                LITESTREAM_SHA256=37be08622b91239ca1a4d417b37889cbac2c6aa83bfcfa6881bcaa7642fc8ee2 \
+            ; \
+            ;; \
+        esac; \
+        wget -q -O litestream.tar.gz https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${LITESTREAM_ARCH}.tar.gz; \
         echo "${LITESTREAM_SHA256} *litestream.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
         tar -xf litestream.tar.gz; \
         mv litestream /usr/local/bin/; \

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,8 +5,6 @@ services:
     # command: headscale serve
     build:
       context: .
-      platforms:
-        - linux/amd64
 
     depends_on:
       - minio

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,11 @@
 services:
   headscale:
     # image: ghcr.io/juanfont/headscale:0.20
-    build: .
     # command: headscale serve
+    build:
+      context: .
+      platforms:
+        - linux/amd64
 
     depends_on:
       - minio

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,8 +12,8 @@ services:
       - minio
 
     environment:
-      - HEADSCALE_SERVER_URL=http://192.168.122.1:8080
-      - HEADSCALE_BASE_DOMAIN=luislavena.info
+      - HEADSCALE_SERVER_URL=http://192.168.106.2:8080
+      - HEADSCALE_BASE_DOMAIN=tn.luislavena.local
       # - HEADSCALE_PRIVATE_KEY=CHANGEME
       # - HEADSCALE_NOISE_PRIVATE_KEY=CHANGEME
       - S3_ACCESS_KEY_ID=admin
@@ -23,8 +23,7 @@ services:
       - S3_ENDPOINT=http://minio:9000
 
     ports:
-      # Listen on virtual bridge (virbr0)
-      - "192.168.122.1:8080:8080"
+      - "8080:8080"
 
     volumes:
       - headscale:/data
@@ -39,8 +38,7 @@ services:
       - MINIO_ROOT_PASSWORD=changeme
 
     ports:
-      # Limit MinIO console to localhost
-      - "127.0.0.1:9090:9090"
+      - "9090:9090"
 
     volumes:
       - minio:/data

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   headscale:
     # image: ghcr.io/juanfont/headscale:0.20

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,6 @@
 ---
 services:
   headscale:
-    # image: ghcr.io/juanfont/headscale:0.20
-    # command: headscale serve
     build:
       context: .
 

--- a/docs/local-dev-using-colima-lima.md
+++ b/docs/local-dev-using-colima-lima.md
@@ -1,0 +1,29 @@
+Create a Colima setup that is reacheable from the network (requires sudo)
+
+```console
+$ colima start --cpu 4 --memory 4 --disk 10 --network-address
+```
+
+Obtain the Colima IP address:
+
+```console
+$ colima list
+PROFILE    STATUS     ARCH       CPUS    MEMORY    DISK     RUNTIME    ADDRESS
+default    Running    aarch64    4       4GiB      10GiB    docker     192.168.106.2
+```
+
+Create two nodes and connect them using `user-v2` network:
+
+```console
+$ limactl start --cpus 2 --memory 2 --name node1 --network=lima:user-v2 template://alpine
+
+$ limactl start --cpus 2 --memory 2 --name node2 --network=lima:user-v2 template://alpine
+```
+
+Check if you can connect from the node to Colima:
+
+```
+$ ssh -F ~/.lima/node1/ssh.config lima-node1
+
+$ ping -c4 192.168.106.2
+```

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -62,7 +62,7 @@ if ! check_socket_directory; then
 fi
 
 echo "INFO: Attempt to restore Headscale database if missing..."
-litestream restore -v -if-db-not-exists -if-replica-exists /data/headscale.sqlite3
+litestream restore -if-db-not-exists -if-replica-exists /data/headscale.sqlite3
 
 echo "INFO: Starting Headscale using Litestream..."
 exec litestream replicate -exec 'headscale serve'

--- a/templates/headscale.template.yaml
+++ b/templates/headscale.template.yaml
@@ -6,9 +6,10 @@ private_key_path: /data/private.key
 noise:
   private_key_path: /data/noise_private.key
 
-ip_prefixes:
-  - 100.64.0.0/10
-  - fd7a:115c:a1e0::/48
+prefixes:
+  allocation: sequential
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
 
 derp:
   server:
@@ -21,8 +22,10 @@ derp:
 # Disables the automatic check for headscale updates on startup
 disable_check_updates: true
 
-db_type: sqlite3
-db_path: /data/headscale.sqlite3
+database:
+  type: sqlite
+  sqlite:
+    path: /data/headscale.sqlite3
 
 # TLS
 tls_cert_path: ""
@@ -32,16 +35,17 @@ log:
   format: text
   level: info
 
-dns_config:
-  override_local_dns: true
+policy:
+  mode: database
+
+dns:
+  magic_dns: true
+  base_domain: $HEADSCALE_BASE_DOMAIN
   nameservers:
     - 1.1.1.1
     - 1.0.0.1
     - 2606:4700:4700::1111
     - 2606:4700:4700::1001
-
-  magic_dns: true
-  base_domain: $HEADSCALE_BASE_DOMAIN
 
 logtail:
   enabled: false


### PR DESCRIPTION
- Latest version of Alpine (3.20)
- Headscale 0.23.0 (fresh from the oven)
- Support for arm64 builds (for those having fun with Ampere Altra or Apple Silicon when testing)