### PR TITLE
Upgrade headscale to 0.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.3
+FROM alpine:3.21.2
 
 # ---
 # upgrade system and installed dependencies for security patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ RUN --mount=type=cache,target=/var/cache/apk \
     cd /tmp; \
     # Headscale
     { \
-        export HEADSCALE_VERSION=0.23.0; \
+        export HEADSCALE_VERSION=0.24.1; \
         case "$(arch)" in \
         x86_64) \
             export \
                 HEADSCALE_ARCH=amd64 \
-                HEADSCALE_SHA256=d9193dad4b070b9b3f6d54c8f14366952944b6e917672c0bc1dfd8f5491287a7 \
+                HEADSCALE_SHA256=28540f5bed81e574dd99b3100ee2fa932ecbb68c6ac093a86f2fc32cb07ff731 \
             ; \
             ;; \
         aarch64) \
             export \
                 HEADSCALE_ARCH=arm64 \
-                HEADSCALE_SHA256=99fa9b2944c50759882b578e78aa11968d6fdec9bbfeced88237a1138b89e9fe \
+                HEADSCALE_SHA256=bf9e94e1caf95f1d67668633f68a4c3bbb4432769b1f8651a501a3f26f6b76ca \
             ; \
             ;; \
         esac; \

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ server URL. Example:
 
 ```
 HEADSCALE_SERVER_URL=https://hs.example.com:443/
-HEADSCALE_BASE_DOMAIN=example.com
+HEADSCALE_BASE_DOMAIN=tn.example.com
 ```
 
 Now, you need to enter your S3 credentials, bucket and endpoint, necessary

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,8 @@ services:
       context: .
 
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
 
     environment:
       - HEADSCALE_SERVER_URL=http://192.168.106.2:8080
@@ -25,19 +26,22 @@ services:
       - headscale:/data
 
   minio:
-    image: quay.io/minio/minio:latest
-    command: minio server /data --console-address ":9090"
-
+    image: bitnami/minio:latest
     environment:
-      - MINIO_REGION=home
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=changeme
-
+      - MINIO_DEFAULT_BUCKETS=homelab
+      - MINIO_SCHEME=http
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     ports:
-      - "9090:9090"
+      - "9001:9001"
 
     volumes:
-      - minio:/data
+      - minio:/bitnami/minio/data
 
 volumes:
   headscale:


### PR DESCRIPTION
This PR introduces a few changes:

1. Uses Bitnami's MinIO setup to ease local testing (as it automatically setup a bucket)
2. Upgrades base Alpine OS to latest (3.21)
3. Adjust the README base domain mention to match the expected configuration (already in place in `compose.yaml`)

Also it updates Headscale to 0.24.1 😉 

This has been tested on existing 0.23.0 setup and seamless upgraded to 0.24.1 without issues.