### PR TITLE
Improve security and reliability with multi-replica support

### DIFF
--- a/.changes/unreleased/changed-20251001-033713.yaml
+++ b/.changes/unreleased/changed-20251001-033713.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Use environment variables directly in Headscale configuration
+time: 2025-10-01T03:37:13.456265+02:00

--- a/.changes/unreleased/changed-20251001-034255.yaml
+++ b/.changes/unreleased/changed-20251001-034255.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Use 2-providers S3 replicas
+time: 2025-10-01T03:42:55.106286+02:00

--- a/.changes/unreleased/changed-20251001-191428.yaml
+++ b/.changes/unreleased/changed-20251001-191428.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade Alpine Linux to latest 3.22.x
+time: 2025-10-01T19:14:28.928428+02:00

--- a/.changes/unreleased/changed-20251001-191846.yaml
+++ b/.changes/unreleased/changed-20251001-191846.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Split Headscale and Litestream container layers
+time: 2025-10-01T19:18:46.461111+02:00

--- a/.changes/unreleased/changed-20251001-194351.yaml
+++ b/.changes/unreleased/changed-20251001-194351.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Run headscale as non-root user
+time: 2025-10-01T19:43:51.171576+02:00

--- a/.changes/unreleased/internal-20251001-030832.yaml
+++ b/.changes/unreleased/internal-20251001-030832.yaml
@@ -1,0 +1,3 @@
+kind: internal
+body: Move testing Compose out of main codebase
+time: 2025-10-01T03:08:32.765542+02:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,3 +89,4 @@ COPY ./templates/litestream.template.yml /etc/litestream.yml
 COPY ./scripts/container-entrypoint.sh /container-entrypoint.sh
 
 ENTRYPOINT ["/container-entrypoint.sh"]
+CMD ["/usr/local/bin/headscale", "/data/headscale.sqlite3", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,38 @@ RUN --mount=type=cache,target=/var/cache/apk \
     }
 
 # ---
-# copy headscale
+# litestream
+RUN --mount=type=tmpfs,target=/tmp \
+    set -eux; \
+    cd /tmp; \
+    { \
+        export LITESTREAM_VERSION=0.3.13; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                LITESTREAM_ARCH=amd64 \
+                LITESTREAM_SHA256=eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a9077948818ba0 \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                LITESTREAM_ARCH=arm64 \
+                LITESTREAM_SHA256=9585f5a508516bd66af2b2376bab4de256a5ef8e2b73ec760559e679628f2d59 \
+            ; \
+            ;; \
+        esac; \
+        wget -q -O litestream.tar.gz https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${LITESTREAM_ARCH}.tar.gz; \
+        echo "${LITESTREAM_SHA256} *litestream.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
+        tar -xf litestream.tar.gz; \
+        mv litestream /usr/local/bin/; \
+        rm -f litestream.tar.gz; \
+    }; \
+    # smoke test
+    [ "$(command -v litestream)" = '/usr/local/bin/litestream' ]; \
+    litestream version
+
+# ---
+# headscale
 RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/tmp \
     set -eux; \
@@ -48,34 +79,8 @@ RUN --mount=type=cache,target=/var/cache/apk \
         chmod +x headscale; \
         mv headscale /usr/local/bin/; \
     }; \
-    # Litestream
-    { \
-        export LITESTREAM_VERSION=0.3.13; \
-        case "$(arch)" in \
-        x86_64) \
-            export \
-                LITESTREAM_ARCH=amd64 \
-                LITESTREAM_SHA256=eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a9077948818ba0 \
-            ; \
-            ;; \
-        aarch64) \
-            export \
-                LITESTREAM_ARCH=arm64 \
-                LITESTREAM_SHA256=9585f5a508516bd66af2b2376bab4de256a5ef8e2b73ec760559e679628f2d59 \
-            ; \
-            ;; \
-        esac; \
-        wget -q -O litestream.tar.gz https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-${LITESTREAM_ARCH}.tar.gz; \
-        echo "${LITESTREAM_SHA256} *litestream.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
-        tar -xf litestream.tar.gz; \
-        mv litestream /usr/local/bin/; \
-        rm -f litestream.tar.gz; \
-    }; \
-    # smoke tests
     [ "$(command -v headscale)" = '/usr/local/bin/headscale' ]; \
-    [ "$(command -v litestream)" = '/usr/local/bin/litestream' ]; \
-    headscale version; \
-    litestream version
+    headscale version
 
 # ---
 # copy configuration and templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 # ---
 # copy configuration and templates
-COPY ./templates/headscale.template.yaml /usr/local/share/headscale/config.template.yaml
+COPY ./templates/headscale.template.yaml /etc/headscale/config.yaml
 COPY ./templates/litestream.template.yml /etc/litestream.yml
 COPY ./scripts/container-entrypoint.sh /container-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
-FROM alpine:3.21.3
+# syntax=registry.docker.com/docker/dockerfile:1
+
+ARG ALPINE_VERSION=3.22.1
+FROM registry.docker.com/library/alpine:${ALPINE_VERSION}
 
 # ---
-# upgrade system and installed dependencies for security patches
-RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
+# system tools & non-root user (1000)
+RUN --mount=type=cache,target=/var/cache/apk \
     set -eux; \
-    apk upgrade
+    { \
+        apk add \
+            su-exec \
+        ; \
+    }; \
+    # non-root user and group
+    { \
+        addgroup -g 1000 headscale; \
+        adduser -u 1000 -G headscale -h /app -s /bin/sh -D headscale; \
+        # cleanup backup copies
+        rm /etc/group- /etc/passwd- /etc/shadow-; \
+    }
 
 # ---
 # copy headscale

--- a/play/compose.yaml
+++ b/play/compose.yaml
@@ -1,15 +1,17 @@
 ---
+name: headscale
+
 services:
-  headscale:
+  server:
     build:
-      context: .
+      context: ..
 
     depends_on:
       minio:
         condition: service_healthy
 
     environment:
-      - HEADSCALE_SERVER_URL=http://192.168.106.2:8080
+      - HEADSCALE_SERVER_URL=https://hs.example.local
       - HEADSCALE_BASE_DOMAIN=tn.luislavena.local
       # - HEADSCALE_PRIVATE_KEY=CHANGEME
       # - HEADSCALE_NOISE_PRIVATE_KEY=CHANGEME
@@ -19,6 +21,12 @@ services:
       - S3_BUCKET_NAME=homelab
       - S3_ENDPOINT=http://minio:9000
 
+    labels:
+      # Ref: https://docs.orbstack.dev/docker/domains#custom
+      - dev.orbstack.domains=hs.example.local
+      # Ref: https://docs.orbstack.dev/docker/domains#ports
+      - dev.orbstack.http-port=8080
+
     ports:
       - "8080:8080"
 
@@ -26,7 +34,7 @@ services:
       - headscale:/data
 
   minio:
-    image: bitnami/minio:latest
+    image: registry.docker.com/bitnamilegacy/minio:latest
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=changeme

--- a/play/compose.yaml
+++ b/play/compose.yaml
@@ -7,7 +7,9 @@ services:
       context: ..
 
     depends_on:
-      minio:
+      replica1:
+        condition: service_healthy
+      replica2:
         condition: service_healthy
 
     environment:
@@ -15,11 +17,18 @@ services:
       - HEADSCALE_BASE_DOMAIN=tn.luislavena.local
       # - HEADSCALE_PRIVATE_KEY=CHANGEME
       # - HEADSCALE_NOISE_PRIVATE_KEY=CHANGEME
-      - S3_ACCESS_KEY_ID=admin
-      - S3_SECRET_ACCESS_KEY=changeme
-      - S3_REGION=home
-      - S3_BUCKET_NAME=homelab
-      - S3_ENDPOINT=http://minio:9000
+      # Replica 1
+      - REPLICA1_BUCKET=mybackup
+      - REPLICA1_ENDPOINT=http://replica1:9000
+      - REPLICA1_REGION=auto
+      - REPLICA1_ACCESS_KEY_ID=keyid
+      - REPLICA1_SECRET_ACCESS_KEY=secretkey
+      # Replica 2
+      - REPLICA2_BUCKET=mybackup
+      - REPLICA2_ENDPOINT=http://replica2:9000
+      - REPLICA2_REGION=auto
+      - REPLICA2_ACCESS_KEY_ID=keyid
+      - REPLICA2_SECRET_ACCESS_KEY=secretkey
 
     labels:
       # Ref: https://docs.orbstack.dev/docker/domains#custom
@@ -33,26 +42,30 @@ services:
     volumes:
       - headscale:/data
 
-  minio:
+  replica1: &replica
     image: registry.docker.com/bitnamilegacy/minio:latest
     environment:
-      - MINIO_ROOT_USER=admin
-      - MINIO_ROOT_PASSWORD=changeme
-      - MINIO_DEFAULT_BUCKETS=homelab
+      - MINIO_ROOT_USER=keyid
+      - MINIO_ROOT_PASSWORD=secretkey
+      - MINIO_DEFAULT_BUCKETS=mybackup
       - MINIO_SCHEME=http
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 10s
       retries: 3
-    ports:
-      - "9001:9001"
-
     volumes:
-      - minio:/bitnami/minio/data
+      - replica1:/bitnamilegacy/minio/data
+
+  replica2:
+    <<: *replica
+    volumes:
+      - replica2:/bitnamilegacy/minio/data
 
 volumes:
   headscale:
     driver: local
-  minio:
+  replica1:
+    driver: local
+  replica2:
     driver: local

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -10,30 +10,19 @@ check_config_files() {
 
 	local abort_config=0
 
-	# check for Headscale config file
-	if [ ! -f $headscale_config_path ]; then
-		echo "INFO: No Headscale configuration file found, creating one using environment variables..."
+	# abort if needed variables are missing
+	if [ -z "$HEADSCALE_SERVER_URL" ]; then
+		echo "ERROR: Required environment variable 'HEADSCALE_SERVER_URL' is missing." >&2
+		abort_config=1
+	fi
 
-		# abort if needed variables are missing
-		if [ -z "$HEADSCALE_SERVER_URL" ]; then
-			echo "ERROR: Required environment variable 'HEADSCALE_SERVER_URL' is missing." >&2
-			abort_config=1
-		fi
+	if [ -z "$HEADSCALE_BASE_DOMAIN" ]; then
+		echo "ERROR: Required environment variable 'HEADSCALE_BASE_DOMAIN' is missing." >&2
+		abort_config=1
+	fi
 
-		if [ -z "$HEADSCALE_BASE_DOMAIN" ]; then
-			echo "ERROR: Required environment variable 'HEADSCALE_BASE_DOMAIN' is missing." >&2
-			abort_config=1
-		fi
-
-		if [ $abort_config -eq 0 ]; then
-			mkdir -p /etc/headscale
-			cp $headscale_config_template $headscale_config_path
-			sed -i "s@\$HEADSCALE_SERVER_URL@$HEADSCALE_SERVER_URL@" $headscale_config_path
-			sed -i "s@\$HEADSCALE_BASE_DOMAIN@$HEADSCALE_BASE_DOMAIN@" $headscale_config_path
-			echo "INFO: Headscale configuration file created."
-		else
-			return $abort_config
-		fi
+	if [ $abort_config -ne 0 ]; then
+		return $abort_config
 	fi
 
 	if [ ! -f $headscale_private_key_path ]; then

--- a/templates/litestream.template.yml
+++ b/templates/litestream.template.yml
@@ -2,11 +2,19 @@
 dbs:
   - path: /data/headscale.sqlite3
     replicas:
-      - name: s3_replica
+      - name: replica1
         type: s3
-        bucket: ${S3_BUCKET_NAME}
+        bucket: ${REPLICA1_BUCKET}
         path: headscale
-        endpoint: ${S3_ENDPOINT}
-        region: ${S3_REGION}
-        access-key-id: ${S3_ACCESS_KEY_ID}
-        secret-access-key: ${S3_SECRET_ACCESS_KEY}
+        endpoint: ${REPLICA1_ENDPOINT}
+        region: ${REPLICA1_REGION}
+        access-key-id: ${REPLICA1_ACCESS_KEY_ID}
+        secret-access-key: ${REPLICA1_SECRET_ACCESS_KEY}
+      - name: replica2
+        type: s3
+        bucket: ${REPLICA2_BUCKET}
+        path: headscale
+        endpoint: ${REPLICA2_ENDPOINT}
+        region: ${REPLICA2_REGION}
+        access-key-id: ${REPLICA2_ACCESS_KEY_ID}
+        secret-access-key: ${REPLICA2_SECRET_ACCESS_KEY}

--- a/templates/litestream.template.yml
+++ b/templates/litestream.template.yml
@@ -1,11 +1,11 @@
 ---
 dbs:
-  - path: /data/headscale.sqlite3
+  - path: ${DB_FILE}
     replicas:
       - name: replica1
         type: s3
         bucket: ${REPLICA1_BUCKET}
-        path: headscale
+        path: ${APP_NAME}
         endpoint: ${REPLICA1_ENDPOINT}
         region: ${REPLICA1_REGION}
         access-key-id: ${REPLICA1_ACCESS_KEY_ID}
@@ -13,7 +13,7 @@ dbs:
       - name: replica2
         type: s3
         bucket: ${REPLICA2_BUCKET}
-        path: headscale
+        path: ${APP_NAME}
         endpoint: ${REPLICA2_ENDPOINT}
         region: ${REPLICA2_REGION}
         access-key-id: ${REPLICA2_ACCESS_KEY_ID}


### PR DESCRIPTION
This introduces several improvements to the Headscale container setup, focusing on security hardening, better configuration management, and enhanced reliability through multi-provider replication.

- Container now runs as non-root user (UID/GID 1000) with proper permission management for database and socket directories. Use `PUID` and `PGID` to adjust it.
- Updated base image to Alpine Linux 3.22.x
- Litestream configuration was updated to support two independent S3-compatible replica providers for better redundancy
- Headscale config template now uses environment variables directly instead of sed replacements at runtime
- Restructured the Dockerfile to separate Litestream and Headscale installation into distinct layers
- Container entrypoint script now accepts application path, database file, and additional arguments for better reusability
