### PR TITLE
Workaround Headscale ENV limitations

### DIFF
--- a/.changes/unreleased/fixed-20251003-124612.yaml
+++ b/.changes/unreleased/fixed-20251003-124612.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Restore variable interpolation in configuration
+time: 2025-10-03T12:46:12.540859+02:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 # ---
 # copy configuration and templates
-COPY ./container/headscale.yaml /etc/headscale/config.yaml
+COPY ./container/headscale.yaml /usr/local/share/headscale/config.template.yaml
 COPY ./container/litestream.yml /etc/litestream.yml
 COPY ./container/entrypoint.sh /entrypoint.sh
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -27,23 +27,35 @@ PGID=${PGID:-1000}
 
 check_config_files() {
 	local headscale_config_path=/etc/headscale/config.yaml
+	local headscale_config_template=/usr/local/share/headscale/config.template.yaml
 	local headscale_noise_private_key_path=/app/data/noise_private.key
 
 	local abort_config=0
 
-	# abort if needed variables are missing
-	if [ -z "$HEADSCALE_SERVER_URL" ]; then
-		echo "ERROR: Required environment variable 'HEADSCALE_SERVER_URL' is missing." >&2
-		abort_config=1
-	fi
+	# check for Headscale config file
+	if [ ! -f $headscale_config_path ]; then
+		echo "INFO: No Headscale configuration file found, creating one using environment variables..."
 
-	if [ -z "$HEADSCALE_BASE_DOMAIN" ]; then
-		echo "ERROR: Required environment variable 'HEADSCALE_BASE_DOMAIN' is missing." >&2
-		abort_config=1
-	fi
+		# abort if needed variables are missing
+		if [ -z "$HEADSCALE_SERVER_URL" ]; then
+			echo "ERROR: Required environment variable 'HEADSCALE_SERVER_URL' is missing." >&2
+			abort_config=1
+		fi
 
-	if [ $abort_config -ne 0 ]; then
-		return $abort_config
+		if [ -z "$HEADSCALE_BASE_DOMAIN" ]; then
+			echo "ERROR: Required environment variable 'HEADSCALE_BASE_DOMAIN' is missing." >&2
+			abort_config=1
+		fi
+
+		if [ $abort_config -eq 0 ]; then
+			mkdir -p /etc/headscale
+			cp $headscale_config_template $headscale_config_path
+			sed -i "s@\$HEADSCALE_SERVER_URL@$HEADSCALE_SERVER_URL@" $headscale_config_path
+			sed -i "s@\$HEADSCALE_BASE_DOMAIN@$HEADSCALE_BASE_DOMAIN@" $headscale_config_path
+			echo "INFO: Headscale configuration file created."
+		else
+			return $abort_config
+		fi
 	fi
 
 	if [ ! -f $headscale_noise_private_key_path ]; then


### PR DESCRIPTION
This partially reverts 19434732ed1ed9a0b67bfdb227d62436f53403b6 as I incorrectly assumed Headscale interpolated environment variables when reading the configuration.

This was a mistake as caused DNS to report `tn.$HEADSCALE_BASE_DOMAIN` instead of the proper domain given.