### PR TITLE
Deal with ENV placeholers in-place

### DIFF
--- a/.changes/unreleased/changed-20251003-185033.yaml
+++ b/.changes/unreleased/changed-20251003-185033.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Change ENV placeholder in-place for broad compatibility
+time: 2025-10-03T18:50:33.307865+02:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN --mount=type=cache,target=/var/cache/apk \
 
 # ---
 # copy configuration and templates
-COPY ./container/headscale.yaml /usr/local/share/headscale/config.template.yaml
+COPY ./container/headscale.yaml /etc/headscale/config.yaml
 COPY ./container/litestream.yml /etc/litestream.yml
 COPY ./container/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Do not rely on copying a template and attempt to replace the placeholders if found.

This works great when mounting an external configuration file or using Docker Compose `configs` functionality.