### PR TITLE
Upgrade Alpine Linux and Headscale, improve validation

### DIFF
--- a/.changes/unreleased/changed-20260307-114117.yaml
+++ b/.changes/unreleased/changed-20260307-114117.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade base Alpine Linux image from 3.23.2 to 3.23.3
+time: 2026-03-07T11:41:17.709164+01:00

--- a/.changes/unreleased/changed-20260307-114321.yaml
+++ b/.changes/unreleased/changed-20260307-114321.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade Headscale from 0.27.1 to 0.28.0
+time: 2026-03-07T11:43:21.502133+01:00

--- a/.changes/unreleased/changed-20260307-115719.yaml
+++ b/.changes/unreleased/changed-20260307-115719.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Expand validation instructions in AGENTS.md with build, runtime, and upgrade steps
+time: 2026-03-07T11:57:19.902875+01:00

--- a/.changes/unreleased/fixed-20260307-115016.yaml
+++ b/.changes/unreleased/fixed-20260307-115016.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Add healthcheck to server service in local development compose
+time: 2026-03-07T11:50:16.04317+01:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,12 +106,65 @@ verification.
 
 ### Validation
 
-Verify changes by:
+All commands below run from the `play/` directory.
 
-1. Running `docker compose build` from `play/` successfully (Dockerfile
-   syntax, checksums, smoke tests)
-2. Testing locally with `docker compose up` from `play/` when changes affect
-   runtime behavior
+#### Build validation
+
+Run `docker compose build` and confirm it completes without errors. This
+verifies Dockerfile syntax, binary downloads, SHA256 checksums, and the
+built-in smoke tests.
+
+#### Runtime validation
+
+When changes affect runtime behavior (entrypoint, config templates, version
+bumps), verify the container starts and operates correctly:
+
+1. Start the stack in detached mode:
+
+   ```
+   docker compose up -d
+   ```
+
+2. Wait for the health check interval (~30 s) and confirm all services
+   report `(healthy)`:
+
+   ```
+   docker compose ps
+   ```
+
+3. Inspect server logs for startup errors or unexpected warnings:
+
+   ```
+   docker compose logs server
+   ```
+
+4. Verify the health endpoint returns HTTP 200:
+
+   ```
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health
+   ```
+
+5. Shut down the stack when done:
+
+   ```
+   docker compose down
+   ```
+
+#### Upgrade validation
+
+When bumping Headscale or Litestream versions, test the database migration
+path to catch incompatibilities early:
+
+1. **Before** applying changes, build and start the current version to
+   create a baseline database (`docker compose build && docker compose up -d`).
+   Confirm the container is healthy, then stop it with
+   `docker compose down`. The database volume persists across restarts.
+2. Apply the version bump and rebuild (`docker compose build`).
+3. Start the stack again (`docker compose up -d`). The new version will
+   open the existing database and run any pending migrations.
+4. Confirm the container reaches `(healthy)` status, check the logs for
+   migration errors, and verify the health endpoint.
+5. Shut down with `docker compose down`.
 
 ## Pull request conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,18 +60,18 @@ RUN --mount=type=cache,target=/var/cache/apk \
     cd /tmp; \
     # Headscale
     { \
-        export HEADSCALE_VERSION=0.27.1; \
+        export HEADSCALE_VERSION=0.28.0; \
         case "$(arch)" in \
         x86_64) \
             export \
                 HEADSCALE_ARCH=amd64 \
-                HEADSCALE_SHA256=af2a232ff407c100f05980b4d8fceaafc7fdb2e8de5eba8e184a8bb029cb6c00 \
+                HEADSCALE_SHA256=95f242a31003d60646d233b14a1acacac20d8f319886d0441df085cc3a920f2d \
             ; \
             ;; \
         aarch64) \
             export \
                 HEADSCALE_ARCH=arm64 \
-                HEADSCALE_SHA256=5af2bd4e18e9267b9770b94ebb60b07e6f32b586b31840b937f628d017e2722a \
+                HEADSCALE_SHA256=0b8d8739b8a243b01afdab04359ebec9e8b16e13d3e7eb4ba71c7c1173c18345 \
             ; \
             ;; \
         esac; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=registry.docker.com/docker/dockerfile:1
 
-ARG ALPINE_VERSION=3.23.2
+ARG ALPINE_VERSION=3.23.3
 FROM registry.docker.com/library/alpine:${ALPINE_VERSION}
 
 # ---

--- a/play/compose.yaml
+++ b/play/compose.yaml
@@ -40,6 +40,12 @@ services:
     ports:
       - "8080:8080"
 
+    healthcheck:
+      test: ["CMD", "headscale", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
     volumes:
       - headscale:/app/data
 


### PR DESCRIPTION
## Summary

- Upgrade base Alpine Linux image from 3.23.2 to 3.23.3 for latest security patches
- Upgrade Headscale from 0.27.1 to 0.28.0, which introduces tags as identity, smarter map updates, and pre-auth key security improvements (minimum Tailscale client version raised to v1.74)
- Improve local testing and validation