### PR TITLE
Upgrading Alpine, Headscale and Litestream

### DIFF
--- a/.changes/unreleased/changed-20260725-212943.yaml
+++ b/.changes/unreleased/changed-20260725-212943.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade to Alpine Linux 3.24.1
+time: 2026-07-25T21:29:43.374383-03:00

--- a/.changes/unreleased/changed-20260725-213004.yaml
+++ b/.changes/unreleased/changed-20260725-213004.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade to Litestream 0.3.14, fixing a panic during database restore
+time: 2026-07-25T21:30:04.372159-03:00

--- a/.changes/unreleased/changed-20260725-213222.yaml
+++ b/.changes/unreleased/changed-20260725-213222.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Move ephemeral node timeout to the new `node.ephemeral.inactivity_timeout` setting
+time: 2026-07-25T21:32:22.381387-03:00

--- a/.changes/unreleased/changed-20260725-213233.yaml
+++ b/.changes/unreleased/changed-20260725-213233.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgrade to Headscale 0.29.2 (upgrade from 0.28.x only, skipping minor versions is blocked)
+time: 2026-07-25T21:32:33.953677-03:00

--- a/.changes/unreleased/fixed-20260726-020556.yaml
+++ b/.changes/unreleased/fixed-20260726-020556.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Take Litestream snapshots hourly to shorten database restores
+time: 2026-07-26T02:05:56.787935-03:00

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=registry.docker.com/docker/dockerfile:1
 
-ARG ALPINE_VERSION=3.23.3
+ARG ALPINE_VERSION=3.24.1
 FROM registry.docker.com/library/alpine:${ALPINE_VERSION}
 
 # ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,18 @@ RUN --mount=type=tmpfs,target=/tmp \
     set -eux; \
     cd /tmp; \
     { \
-        export LITESTREAM_VERSION=0.3.13; \
+        export LITESTREAM_VERSION=0.3.14; \
         case "$(arch)" in \
         x86_64) \
             export \
                 LITESTREAM_ARCH=amd64 \
-                LITESTREAM_SHA256=eb75a3de5cab03875cdae9f5f539e6aedadd66607003d9b1e7a9077948818ba0 \
+                LITESTREAM_SHA256=880ccafc9514650c4a2a0cc78eb1e61aaad95dd3e86e877c8694f955c9095436 \
             ; \
             ;; \
         aarch64) \
             export \
                 LITESTREAM_ARCH=arm64 \
-                LITESTREAM_SHA256=9585f5a508516bd66af2b2376bab4de256a5ef8e2b73ec760559e679628f2d59 \
+                LITESTREAM_SHA256=4d375a66653e4a9b27a5b38ce9cb73681c39893ba0485f81ab860d4cd427e642 \
             ; \
             ;; \
         esac; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,18 +60,18 @@ RUN --mount=type=cache,target=/var/cache/apk \
     cd /tmp; \
     # Headscale
     { \
-        export HEADSCALE_VERSION=0.28.0; \
+        export HEADSCALE_VERSION=0.29.2; \
         case "$(arch)" in \
         x86_64) \
             export \
                 HEADSCALE_ARCH=amd64 \
-                HEADSCALE_SHA256=95f242a31003d60646d233b14a1acacac20d8f319886d0441df085cc3a920f2d \
+                HEADSCALE_SHA256=858ef94bca9ecdfc742c24119c831e437e1b75691fdd5041be4059db1a38aac0 \
             ; \
             ;; \
         aarch64) \
             export \
                 HEADSCALE_ARCH=arm64 \
-                HEADSCALE_SHA256=0b8d8739b8a243b01afdab04359ebec9e8b16e13d3e7eb4ba71c7c1173c18345 \
+                HEADSCALE_SHA256=7f458586fcb4ba5832e4fa7b097948ec99fbca2bb4dd02b335a379f78e7807ac \
             ; \
             ;; \
         esac; \

--- a/container/headscale.yaml
+++ b/container/headscale.yaml
@@ -19,8 +19,10 @@ derp:
 # Disables the automatic check for headscale updates on startup
 disable_check_updates: true
 
-# Remove ephemeral nodes after being inactive
-ephemeral_node_inactivity_timeout: 30m
+node:
+  # Remove ephemeral nodes after being inactive
+  ephemeral:
+    inactivity_timeout: 30m
 
 database:
   type: sqlite

--- a/container/litestream.yml
+++ b/container/litestream.yml
@@ -10,6 +10,8 @@ dbs:
         region: ${REPLICA1_REGION}
         access-key-id: ${REPLICA1_ACCESS_KEY_ID}
         secret-access-key: ${REPLICA1_SECRET_ACCESS_KEY}
+        snapshot-interval: 1h
+        retention: 24h
       - name: replica2
         type: s3
         bucket: ${REPLICA2_BUCKET}
@@ -18,3 +20,5 @@ dbs:
         region: ${REPLICA2_REGION}
         access-key-id: ${REPLICA2_ACCESS_KEY_ID}
         secret-access-key: ${REPLICA2_SECRET_ACCESS_KEY}
+        snapshot-interval: 1h
+        retention: 24h


### PR DESCRIPTION
Routine maintenance to keep the packaged image on current upstream releases.

Headscale now refuses to start when a minor version is skipped, which makes staying close to the current release a practical requirement rather than a preference. Keeping the bundled config aligned with the settings upstream currently expects serves the same goal: avoid accumulating deprecations that turn into a blocked start later.

Tweak Litestream config to reduce number of WAL files when restoring the database.

Existing deployments must already run 0.28.x (v0.6.0). Anyone still on 0.27 (v0.5.0 or lower) needs to go through v0.6.0 first.